### PR TITLE
removing unecessary rule in brunch config

### DIFF
--- a/brunch-config.js
+++ b/brunch-config.js
@@ -1,20 +1,12 @@
 exports.config = {
   hot: true,
 
-  plugins: {
-    babel: {
-      presets: ['es2015', 'react']
-    }
-  },
-
   files: {
-    javascripts: {
-      joinTo: 'app.js'
-    },
-    stylesheets: {joinTo: 'app.css'}
+    javascripts: { joinTo: 'app.js' },
+    stylesheets: { joinTo: 'app.css' }
   },
 
   plugins: {
-    babel: {presets: ['es2015', 'react']}
+    babel: { presets: ['es2015', 'react'] }
   }
 };


### PR DESCRIPTION
The `plugins` entry is duplicated in `brunch-config.js`
