### PR TITLE
Enable usage of object spread operator

### DIFF
--- a/app/components/Counter.jsx
+++ b/app/components/Counter.jsx
@@ -19,7 +19,7 @@ BaseCounter.propTypes = {
 };
 
 const mapStateToProps = state => {
-  return { count: state };
+  return { count: state.count };
 };
 
 const mapDispatchToProps = dispatch => {

--- a/app/initialize.js
+++ b/app/initialize.js
@@ -2,10 +2,10 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
-import counterApp from './reducers';
+import counterApp, { initialState } from './reducers';
 import App from 'components/App';
 
-const store = createStore(counterApp, module.hot && module.hot.data && module.hot.data.counter || 0);
+const store = createStore(counterApp, module.hot && module.hot.data && module.hot.data.counter || initialState);
 
 if (module.hot) {
   module.hot.accept('./reducers', () => {

--- a/app/reducers.js
+++ b/app/reducers.js
@@ -1,9 +1,12 @@
-export default (state = 0, action) => {
+const initialState = {count: 0};
+export { initialState };
+
+export default (state = initialState, action) => {
   switch (action.type) {
     case 'INCREMENT':
-      return state + 1;
+      return { ...state, count: state.count + 1};
     case 'DECREMENT':
-      return state - 1;
+      return { ...state, count: state.count - 1};
     default:
       return state
   }

--- a/brunch-config.js
+++ b/brunch-config.js
@@ -7,7 +7,7 @@ exports.files = {
 };
 
 exports.plugins = {
-  babel: {presets: ['latest', 'react']}
+  babel: {presets: ['latest', 'react', 'stage-2']}
 };
 
 exports.hot = true;

--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
   },
   "devDependencies": {
     "auto-reload-brunch": "^2",
-    "hmr-brunch": "^0.1",
     "babel-brunch": "~6.0.0",
     "babel-preset-latest": "^6",
     "babel-preset-react": "~6.22",
+    "babel-preset-stage-2": "^6.22.0",
     "brunch": "^2",
     "clean-css-brunch": "^2",
+    "hmr-brunch": "^0.1",
     "uglify-js-brunch": "^2"
   }
 }


### PR DESCRIPTION
The redux docs lean toward using the experimental object spread operator.  
create-react-app now enables this by default, so I thought it might be nice to have in a brunch skeleton as well.  